### PR TITLE
Add link to marketplace in theme preview

### DIFF
--- a/app/routes/e/$extensionSlug/$themeSlug.tsx
+++ b/app/routes/e/$extensionSlug/$themeSlug.tsx
@@ -170,6 +170,9 @@ export default function ThemeView() {
               <Link reloadDocument to="open?with=web" className="button button-secondary">
                 VS Code for the Web
               </Link>
+              <Link reloadDocument to=`https://marketplace.visualstudio.com/items?itemName=${extensionSlug}` className="button button-secondary">
+                View on Marketplace
+              </Link>
             </div>
           </div>
         </div>

--- a/app/routes/e/$extensionSlug/$themeSlug.tsx
+++ b/app/routes/e/$extensionSlug/$themeSlug.tsx
@@ -170,7 +170,7 @@ export default function ThemeView() {
               <Link reloadDocument to="open?with=web" className="button button-secondary">
                 VS Code for the Web
               </Link>
-              <Link reloadDocument to=`https://marketplace.visualstudio.com/items?itemName=${extensionSlug}` className="button button-secondary">
+              <Link reloadDocument to={`https://marketplace.visualstudio.com/items?itemName=${extensionSlug}`} className="button button-secondary">
                 View on Marketplace
               </Link>
             </div>


### PR DESCRIPTION
Adds a link to the VSCode marketplace on the theme preview window, so that users don't need to open VSCode to have access to it.

This also partially addresses https://github.com/vscodethemes/web/issues/252, as it allows VSCodium users to manually download the `.vsix` on the marketplace page.