### PR TITLE
Update e.$slug.$theme.tsx

### DIFF
--- a/app/routes/e.$slug.$theme.tsx
+++ b/app/routes/e.$slug.$theme.tsx
@@ -277,6 +277,7 @@ export default function ExtensionThemeRoute() {
                   >
                     <Link
                       to={`/e/${extension.publisherName}.${extension.name}/${theme.name}/open?with=vscodeweb`}
+                      target="_blank"
                       reloadDocument
                     >
                       VS Code for Web


### PR DESCRIPTION
added blank target to the vscode web link. It's super annoying to have to go back to the vscode themes page after trying each theme